### PR TITLE
Update test_outlier_handler.py

### DIFF
--- a/feature_engine/tests/test_outlier_handler.py
+++ b/feature_engine/tests/test_outlier_handler.py
@@ -8,7 +8,7 @@ import pytest
 from outlier_handler import Windsorizer
 
 import os
-filename = os.path.dirname(os.path.abspath(__file__)) + os.sep + 'titanic_test.csv'
+filename = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'titanic_test.csv')
 df_test = pd.read_csv(filename)
 
     


### PR DESCRIPTION
Modified to use os.path.join which is less verbose and preferred.

See: https://stackoverflow.com/questions/16789714/differences-between-use-of-os-path-join-and-os-sep-concatenation