### PR TITLE
change pypi upload to release branch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -108,4 +108,4 @@ workflows:
           filters:
             branches:
               only:
-                - master
+                - 0.6.X


### PR DESCRIPTION
@ChristopherGS I updated circle ci yaml so it uploads to pypi from a release branch instead of master, as I have seen other libraries do (eg sklearn). Would you mind having a quick look and approving my PR?