### PR TITLE
rename class init params and defo values

### DIFF
--- a/feature_engine/imputation/end_tail.py
+++ b/feature_engine/imputation/end_tail.py
@@ -55,14 +55,14 @@ class EndTailImputer(BaseImputer):
     Parameters
     ----------
 
-    distribution : str, default=gaussian
+    imputation_method : str, default=gaussian
         Method to be used to find the replacement values. Can take 'gaussian',
-        'skewed' or 'max'.
+        'iqr' or 'max'.
 
         gaussian: the imputer will use the Gaussian limits to find the values
         to replace missing data.
 
-        skewed: the imputer will use the IQR limits to find the values to replace
+        iqr: the imputer will use the IQR limits to find the values to replace
         missing data.
 
         max: the imputer will use the maximum values to replace missing data. Note
@@ -81,10 +81,10 @@ class EndTailImputer(BaseImputer):
         select all variables of type numeric.
     """
 
-    def __init__(self, distribution='gaussian', tail='right', fold=3, variables=None):
+    def __init__(self, imputation_method='gaussian', tail='right', fold=3, variables=None):
 
-        if distribution not in ['gaussian', 'skewed', 'max']:
-            raise ValueError("distribution takes only values 'gaussian', 'skewed' or 'max'")
+        if imputation_method not in ['gaussian', 'iqr', 'max']:
+            raise ValueError("distribution takes only values 'gaussian', 'iqr' or 'max'")
 
         if tail not in ['right', 'left']:
             raise ValueError("tail takes only values 'right' or 'left'")
@@ -92,7 +92,7 @@ class EndTailImputer(BaseImputer):
         if fold <= 0:
             raise ValueError("fold takes only positive numbers")
 
-        self.distribution = distribution
+        self.imputation_method = imputation_method
         self.tail = tail
         self.fold = fold
         self.variables = _define_variables(variables)
@@ -126,16 +126,16 @@ class EndTailImputer(BaseImputer):
         self.variables = _find_numerical_variables(X, self.variables)
 
         # estimate imputation values
-        if self.distribution == 'max':
+        if self.imputation_method == 'max':
             self.imputer_dict_ = (X[self.variables].max() * self.fold).to_dict()
 
-        elif self.distribution == 'gaussian':
+        elif self.imputation_method == 'gaussian':
             if self.tail == 'right':
                 self.imputer_dict_ = (X[self.variables].mean() + self.fold * X[self.variables].std()).to_dict()
             elif self.tail == 'left':
                 self.imputer_dict_ = (X[self.variables].mean() - self.fold * X[self.variables].std()).to_dict()
 
-        elif self.distribution == 'skewed':
+        elif self.imputation_method == 'iqr':
             IQR = X[self.variables].quantile(0.75) - X[self.variables].quantile(0.25)
             if self.tail == 'right':
                 self.imputer_dict_ = (X[self.variables].quantile(0.75) + (IQR * self.fold)).to_dict()

--- a/feature_engine/imputation/missing_indicator.py
+++ b/feature_engine/imputation/missing_indicator.py
@@ -32,14 +32,14 @@ class AddMissingIndicator(BaseEstimator, TransformerMixin):
     Parameters
     ----------
 
-    how : string, defatul='missing_only'
+    missing_only : bool, defatult=True
         Indicates if missing indicators should be added to variables with missing
         data or to all variables.
 
-        missing_only: indicators will be created only for those variables that showed
+        True: indicators will be created only for those variables that showed
         missing data during fit.
 
-        all: indicators will be created for all variables
+        False: indicators will be created for all variables
 
     variables : list, default=None
         The list of variables to be imputed. If None, the imputer will find and
@@ -49,13 +49,13 @@ class AddMissingIndicator(BaseEstimator, TransformerMixin):
         that show missing data in during fit.
     """
 
-    def __init__(self, how='missing_only', variables=None):
+    def __init__(self, missing_only=True, variables=None):
 
-        if how not in ['missing_only', 'all']:
-            raise ValueError("how takes only values 'missing_only' or 'all'")
+        if not isinstance(missing_only, bool):
+            raise ValueError("missing_only takes values True or False")
 
         self.variables = _define_variables(variables)
-        self.how = how
+        self.missing_only = missing_only
 
     def fit(self, X, y=None):
         """
@@ -81,13 +81,13 @@ class AddMissingIndicator(BaseEstimator, TransformerMixin):
         X = _is_dataframe(X)
 
         # find variables for which indicator should be added
-        if self.how == 'missing_only':
+        if self.missing_only:
             if not self.variables:
                 self.variables_ = [var for var in X.columns if X[var].isnull().sum() > 0]
             else:
                 self.variables_ = [var for var in self.variables if X[var].isnull().sum() > 0]
 
-        elif self.how == 'all':
+        else:
             if not self.variables:
                 self.variables_ = [var for var in X.columns]
             else:

--- a/feature_engine/outliers/trimmer.py
+++ b/feature_engine/outliers/trimmer.py
@@ -56,7 +56,7 @@ class OutlierTrimmer(Winsorizer):
 
     If distribution='gaussian' fold gives the value to multiply the std.
 
-    If distribution='skewed' fold is the value to multiply the IQR.
+    If distribution='iqr' fold is the value to multiply the IQR.
 
     If distribution='quantile', fold is the percentile on each tail that should
     be censored. For example, if fold=0.05, the limits will be the 5th and 95th
@@ -72,12 +72,12 @@ class OutlierTrimmer(Winsorizer):
     ----------
 
     distribution : str, default=gaussian
-        Desired distribution. Can take 'gaussian', 'skewed' or 'quantiles'.
+        Desired distribution. Can take 'gaussian', 'iqr' or 'quantiles'.
 
         gaussian: the transformer will find the maximum and / or minimum values to
         cap the variables using the Gaussian approximation.
 
-        skewed: the transformer will find the boundaries using the IQR proximity rule.
+        iqr: the transformer will find the boundaries using the IQR proximity rule.
 
         quantiles: the limits are given by the percentiles.
 

--- a/tests/test_imputation/test_end_tail_imputer.py
+++ b/tests/test_imputation/test_end_tail_imputer.py
@@ -8,7 +8,7 @@ from feature_engine.imputation import EndTailImputer
 def test_EndTailImputer(dataframe_na):
 
     # test case 1: automatically find variables + gaussian limits + right tail
-    imputer = EndTailImputer(distribution='gaussian', tail='right', fold=3, variables=None)
+    imputer = EndTailImputer(imputation_method='gaussian', tail='right', fold=3, variables=None)
     X_transformed = imputer.fit_transform(dataframe_na)
 
     ref_df = dataframe_na.copy()
@@ -16,7 +16,7 @@ def test_EndTailImputer(dataframe_na):
     ref_df['Marks'] = ref_df['Marks'].fillna(1.3244261503263175)
 
     # init params
-    assert imputer.distribution == 'gaussian'
+    assert imputer.imputation_method == 'gaussian'
     assert imputer.tail == 'right'
     assert imputer.fold == 3
     assert imputer.variables == ['Age', 'Marks']
@@ -29,7 +29,7 @@ def test_EndTailImputer(dataframe_na):
     pd.testing.assert_frame_equal(X_transformed, ref_df)
 
     # test case 2: selected variables + IQR rule + right tail
-    imputer = EndTailImputer(distribution='skewed', tail='right', fold=1.5, variables=['Age', 'Marks'])
+    imputer = EndTailImputer(imputation_method='iqr', tail='right', fold=1.5, variables=['Age', 'Marks'])
     X_transformed = imputer.fit_transform(dataframe_na)
 
     ref_df = dataframe_na.copy()
@@ -41,22 +41,22 @@ def test_EndTailImputer(dataframe_na):
     pd.testing.assert_frame_equal(X_transformed, ref_df)
 
     # test case 3: selected variables + maximum value
-    imputer = EndTailImputer(distribution='max', tail='right', fold=2, variables=['Age', 'Marks'])
+    imputer = EndTailImputer(imputation_method='max', tail='right', fold=2, variables=['Age', 'Marks'])
     imputer.fit(dataframe_na)
     assert imputer.imputer_dict_ == {'Age': 82.0, 'Marks': 1.8}
 
     # test case 4: automatically select variables + gaussian limits + left tail
-    imputer = EndTailImputer(distribution='gaussian', tail='left', fold=3)
+    imputer = EndTailImputer(imputation_method='gaussian', tail='left', fold=3)
     imputer.fit(dataframe_na)
     assert imputer.imputer_dict_ == {'Age': -1.520509756212462, 'Marks': 0.04224051634034898}
 
     # test case 5: IQR + left tail
-    imputer = EndTailImputer(distribution='skewed', tail='left', fold=1.5, variables=['Age', 'Marks'])
+    imputer = EndTailImputer(imputation_method='iqr', tail='left', fold=1.5, variables=['Age', 'Marks'])
     imputer.fit(dataframe_na)
     assert imputer.imputer_dict_ == {'Age': -6.5, 'Marks': 0.36249999999999993}
 
     with pytest.raises(ValueError):
-        EndTailImputer(distribution='arbitrary')
+        EndTailImputer(imputation_method='arbitrary')
 
     with pytest.raises(ValueError):
         EndTailImputer(tail='arbitrary')

--- a/tests/test_imputation/test_missing_indicator.py
+++ b/tests/test_imputation/test_missing_indicator.py
@@ -7,12 +7,12 @@ from feature_engine.imputation import AddMissingIndicator
 def test_AddMissingIndicator(dataframe_na):
 
     # test case 1: automatically detect variables with missing data
-    imputer = AddMissingIndicator(how='missing_only', variables=None)
+    imputer = AddMissingIndicator(missing_only=True, variables=None)
     X_transformed = imputer.fit_transform(dataframe_na)
 
     # init params
-    assert imputer.how == 'missing_only'
-    assert imputer.variables == None
+    assert imputer.missing_only is True
+    assert imputer.variables is None
     # fit params
     assert imputer.variables_ == ['Name', 'City', 'Studies', 'Age', 'Marks']
     assert imputer.input_shape_ == (8, 6)
@@ -22,7 +22,7 @@ def test_AddMissingIndicator(dataframe_na):
     assert X_transformed['Name_na'].sum() == 2
 
     # test case 2: automatically detect all columns
-    imputer = AddMissingIndicator(how='all', variables=None)
+    imputer = AddMissingIndicator(missing_only=False, variables=None)
     X_transformed = imputer.fit_transform(dataframe_na)
     assert imputer.variables_ == ['Name', 'City', 'Studies', 'Age', 'Marks', 'dob']
     assert X_transformed.shape == (8, 12)
@@ -30,7 +30,7 @@ def test_AddMissingIndicator(dataframe_na):
     assert X_transformed['dob_na'].sum() == 0
 
     # test case 3: find variables with NA, among those entered by the user
-    imputer = AddMissingIndicator(how='missing_only', variables=['City', 'Studies', 'Age', 'dob'])
+    imputer = AddMissingIndicator(missing_only=True, variables=['City', 'Studies', 'Age', 'dob'])
     X_transformed = imputer.fit_transform(dataframe_na)
     assert imputer.variables == ['City', 'Studies', 'Age', 'dob']
     assert imputer.variables_ == ['City', 'Studies', 'Age']
@@ -40,7 +40,7 @@ def test_AddMissingIndicator(dataframe_na):
     assert X_transformed['City_na'].sum() == 2
 
     with pytest.raises(ValueError):
-        AddMissingIndicator(how='arbitrary')
+        AddMissingIndicator(missing_only='missing_only')
 
     with pytest.raises(NotFittedError):
         imputer = AddMissingIndicator()

--- a/tests/test_outliers/test_outlier_trimmer.py
+++ b/tests/test_outliers/test_outlier_trimmer.py
@@ -9,7 +9,7 @@ from feature_engine.outliers import OutlierTrimmer
 
 def test_OutlierTrimmer(dataframe_normal_dist, dataframe_na):
     # test case 1: mean and std, right tail
-    transformer = OutlierTrimmer(distribution='gaussian', tail='right', fold=1)
+    transformer = OutlierTrimmer(capping_method='gaussian', tail='right', fold=1)
     X = transformer.fit_transform(dataframe_normal_dist)
 
     df_transf = dataframe_normal_dist.copy()
@@ -21,12 +21,12 @@ def test_OutlierTrimmer(dataframe_normal_dist, dataframe_na):
     assert len(X) == 83
 
     # test case 2: mean and std, both tails, different fold value
-    transformer = OutlierTrimmer(distribution='gaussian', tail='both', fold=2)
+    transformer = OutlierTrimmer(capping_method='gaussian', tail='both', fold=2)
     X = transformer.fit_transform(dataframe_normal_dist)
     assert len(X) == 96
 
     # test case 3: IQR, left tail, fold 2
-    transformer = OutlierTrimmer(distribution='skewed', tail='left', fold=0.8)
+    transformer = OutlierTrimmer(capping_method='iqr', tail='left', fold=0.8)
     X = transformer.fit_transform(dataframe_normal_dist)
 
     df_transf = dataframe_normal_dist.copy()
@@ -37,7 +37,7 @@ def test_OutlierTrimmer(dataframe_normal_dist, dataframe_na):
     assert len(X) == 98
 
     # test case 4: dataset contains na, and transformer is asked to ignore
-    transformer = OutlierTrimmer(distribution='gaussian', tail='right', fold=1,
+    transformer = OutlierTrimmer(capping_method='gaussian', tail='right', fold=1,
                                  variables=['Age'], missing_values='ignore')
     X = transformer.fit_transform(dataframe_na)
 

--- a/tests/test_outliers/test_winsorizer.py
+++ b/tests/test_outliers/test_winsorizer.py
@@ -8,14 +8,14 @@ from feature_engine.outliers import Winsorizer
 
 def test_Windsorizer(dataframe_normal_dist, dataframe_na, dataframe_vartypes):
     # test case 1: mean and std, right tail
-    transformer = Winsorizer(distribution='gaussian', tail='right', fold=1)
+    transformer = Winsorizer(capping_method='gaussian', tail='right', fold=1)
     X = transformer.fit_transform(dataframe_normal_dist)
 
     df_transf = dataframe_normal_dist.copy()
     df_transf['var'] = np.where(df_transf['var'] > 0.10727677848029868, 0.10727677848029868, df_transf['var'])
 
     # init params
-    assert transformer.distribution == 'gaussian'
+    assert transformer.capping_method == 'gaussian'
     assert transformer.tail == 'right'
     assert transformer.fold == 1
     # fit params
@@ -28,7 +28,7 @@ def test_Windsorizer(dataframe_normal_dist, dataframe_na, dataframe_vartypes):
     assert dataframe_normal_dist['var'].max() > 0.10727677848029868
 
     # test case 2: mean and std, both tails, different fold value
-    transformer = Winsorizer(distribution='gaussian', tail='both', fold=2)
+    transformer = Winsorizer(capping_method='gaussian', tail='both', fold=2)
     X = transformer.fit_transform(dataframe_normal_dist)
 
     df_transf = dataframe_normal_dist.copy()
@@ -46,7 +46,7 @@ def test_Windsorizer(dataframe_normal_dist, dataframe_na, dataframe_vartypes):
     assert dataframe_normal_dist['var'].min() < -0.19661115230025186
 
     # test case 3: IQR, both tails, fold 1
-    transformer = Winsorizer(distribution='skewed', tail='both', fold=1)
+    transformer = Winsorizer(capping_method='iqr', tail='both', fold=1)
     X = transformer.fit_transform(dataframe_normal_dist)
 
     df_transf = dataframe_normal_dist.copy()
@@ -64,7 +64,7 @@ def test_Windsorizer(dataframe_normal_dist, dataframe_na, dataframe_vartypes):
     assert dataframe_normal_dist['var'].min() < -0.20247907173293223
 
     # test case 4: IQR, left tail, fold 2
-    transformer = Winsorizer(distribution='skewed', tail='left', fold=0.8)
+    transformer = Winsorizer(capping_method='iqr', tail='left', fold=0.8)
     X = transformer.fit_transform(dataframe_normal_dist)
 
     df_transf = dataframe_normal_dist.copy()
@@ -79,7 +79,7 @@ def test_Windsorizer(dataframe_normal_dist, dataframe_na, dataframe_vartypes):
     assert dataframe_normal_dist['var'].min() < -0.17486039103044
 
     # test case 5: quantiles, both tails, fold 10%
-    transformer = Winsorizer(distribution='quantiles', tail='both', fold=0.1)
+    transformer = Winsorizer(capping_method='quantiles', tail='both', fold=0.1)
     X = transformer.fit_transform(dataframe_normal_dist)
 
     df_transf = dataframe_normal_dist.copy()
@@ -97,7 +97,7 @@ def test_Windsorizer(dataframe_normal_dist, dataframe_na, dataframe_vartypes):
     assert dataframe_normal_dist['var'].min() < -0.12366227743232801
 
     # test case 6: quantiles, right tail, fold 15%
-    transformer = Winsorizer(distribution='quantiles', tail='right', fold=0.15)
+    transformer = Winsorizer(capping_method='quantiles', tail='right', fold=0.15)
     X = transformer.fit_transform(dataframe_normal_dist)
 
     df_transf = dataframe_normal_dist.copy()
@@ -112,7 +112,7 @@ def test_Windsorizer(dataframe_normal_dist, dataframe_na, dataframe_vartypes):
     assert dataframe_normal_dist['var'].max() > 0.11823196128033647
 
     # test case 7: dataset contains na and transformer is asked to ignore them
-    transformer = Winsorizer(distribution='gaussian', tail='right', fold=1,
+    transformer = Winsorizer(capping_method='gaussian', tail='right', fold=1,
                              variables=['Age', 'Marks'],
                              missing_values='ignore')
     X = transformer.fit_transform(dataframe_na)
@@ -132,7 +132,7 @@ def test_Windsorizer(dataframe_normal_dist, dataframe_na, dataframe_vartypes):
 
     # test error raises
     with pytest.raises(ValueError):
-        Winsorizer(distribution='other')
+        Winsorizer(capping_method='other')
 
     with pytest.raises(ValueError):
         Winsorizer(tail='other')
@@ -144,7 +144,7 @@ def test_Windsorizer(dataframe_normal_dist, dataframe_na, dataframe_vartypes):
         Winsorizer(fold=-1)
 
     with pytest.raises(ValueError):
-        Winsorizer(distribution='quantiles', fold=0.3)
+        Winsorizer(capping_method='quantiles', fold=0.3)
 
     # test case 8: when dataset contains na, fit method
     with pytest.raises(ValueError):


### PR DESCRIPTION
Rename params:
end_tail_imputer: distribution is now imputation_method, skewed is now iqr

addmissingindicator: how is now missing_only and takes true/false

winsorizer: distribution is not capping_method and skewed is now iqr
trimmer: the same (inherits winsorizer)