### PR TITLE
round numbers in test_winsorizer.py

### DIFF
--- a/0.11.1
+++ b/0.11.1
@@ -1,0 +1,12 @@
+Collecting statsmodels
+  Downloading statsmodels-0.12.2-cp37-none-win_amd64.whl (9.3 MB)
+Requirement already satisfied: pandas>=0.21 in c:\users\inavarro\desktop\projects\feature_engine\feature_engine\.env\lib\site-packages (from statsmodels) (1.2.3)
+Requirement already satisfied: scipy>=1.1 in c:\users\inavarro\desktop\projects\feature_engine\feature_engine\.env\lib\site-packages (from statsmodels) (1.6.1)
+Collecting patsy>=0.5
+  Downloading patsy-0.5.1-py2.py3-none-any.whl (231 kB)
+Requirement already satisfied: numpy>=1.15 in c:\users\inavarro\desktop\projects\feature_engine\feature_engine\.env\lib\site-packages (from statsmodels) (1.20.1)
+Requirement already satisfied: pytz>=2017.3 in c:\users\inavarro\desktop\projects\feature_engine\feature_engine\.env\lib\site-packages (from pandas>=0.21->statsmodels) (2021.1)
+Requirement already satisfied: python-dateutil>=2.7.3 in c:\users\inavarro\desktop\projects\feature_engine\feature_engine\.env\lib\site-packages (from pandas>=0.21->statsmodels) (2.8.1)
+Requirement already satisfied: six in c:\users\inavarro\desktop\projects\feature_engine\feature_engine\.env\lib\site-packages (from patsy>=0.5->statsmodels) (1.15.0)
+Installing collected packages: patsy, statsmodels
+Successfully installed patsy-0.5.1 statsmodels-0.12.2

--- a/0.22.2
+++ b/0.22.2
@@ -1,0 +1,11 @@
+Collecting scikit-learn
+  Downloading scikit_learn-0.24.1-cp37-cp37m-win_amd64.whl (6.8 MB)
+Collecting joblib>=0.11
+  Downloading joblib-1.0.1-py3-none-any.whl (303 kB)
+Requirement already satisfied: numpy>=1.13.3 in c:\users\inavarro\desktop\projects\feature_engine\feature_engine\.env\lib\site-packages (from scikit-learn) (1.20.1)
+Collecting scipy>=0.19.1
+  Downloading scipy-1.6.1-cp37-cp37m-win_amd64.whl (32.6 MB)
+Collecting threadpoolctl>=2.0.0
+  Downloading threadpoolctl-2.1.0-py3-none-any.whl (12 kB)
+Installing collected packages: threadpoolctl, scipy, joblib, scikit-learn
+Successfully installed joblib-1.0.1 scikit-learn-0.24.1 scipy-1.6.1 threadpoolctl-2.1.0

--- a/1.0.3
+++ b/1.0.3
@@ -1,0 +1,11 @@
+Collecting pandas
+  Using cached pandas-1.2.3-cp37-cp37m-win_amd64.whl (9.1 MB)
+Collecting pytz>=2017.3
+  Using cached pytz-2021.1-py2.py3-none-any.whl (510 kB)
+Requirement already satisfied: numpy>=1.16.5 in c:\users\inavarro\desktop\projects\feature_engine\feature_engine\.env\lib\site-packages (from pandas) (1.20.1)
+Collecting python-dateutil>=2.7.3
+  Using cached python_dateutil-2.8.1-py2.py3-none-any.whl (227 kB)
+Collecting six>=1.5
+  Using cached six-1.15.0-py2.py3-none-any.whl (10 kB)
+Installing collected packages: six, pytz, python-dateutil, pandas
+Successfully installed pandas-1.2.3 python-dateutil-2.8.1 pytz-2021.1 six-1.15.0

--- a/1.18.2
+++ b/1.18.2
@@ -1,0 +1,4 @@
+Collecting numpy
+  Using cached numpy-1.20.1-cp37-cp37m-win_amd64.whl (13.6 MB)
+Installing collected packages: numpy
+Successfully installed numpy-1.20.1

--- a/1.4.1
+++ b/1.4.1
@@ -1,0 +1,2 @@
+Requirement already satisfied: scipy in c:\users\inavarro\desktop\projects\feature_engine\feature_engine\.env\lib\site-packages (1.6.1)
+Requirement already satisfied: numpy>=1.16.5 in c:\users\inavarro\desktop\projects\feature_engine\feature_engine\.env\lib\site-packages (from scipy) (1.20.1)

--- a/tests/test_outliers/test_winsorizer.py
+++ b/tests/test_outliers/test_winsorizer.py
@@ -22,13 +22,13 @@ def test_gaussian_capping_right_tail_with_fold_1(df_normal_dist):
     assert transformer.tail == "right"
     assert transformer.fold == 1
     # test fit attr
-    assert transformer.right_tail_caps_ == {"var": 0.10727677848029868}
+    assert np.round(transformer.right_tail_caps_['var'],3)   == np.round({"var": 0.10727677848029868}['var'],3)
     assert transformer.left_tail_caps_ == {}
     assert transformer.input_shape_ == (100, 1)
     # test transform outputs
     pd.testing.assert_frame_equal(X, df_transf)
-    assert X["var"].max() <= 0.10727677848029868
-    assert df_normal_dist["var"].max() > 0.10727677848029868
+    assert np.round(X["var"].max(),3) <= np.round(0.10727677848029868,3)
+    assert np.round(df_normal_dist["var"].max(),3) > np.round(0.10727677848029868,3)
 
 
 def test_gaussian_capping_both_tails_with_fold_2(df_normal_dist):
@@ -46,14 +46,14 @@ def test_gaussian_capping_both_tails_with_fold_2(df_normal_dist):
     )
 
     # test fit params
-    assert transformer.right_tail_caps_ == {"var": 0.20857275540714884}
-    assert transformer.left_tail_caps_ == {"var": -0.19661115230025186}
+    assert np.round(transformer.right_tail_caps_['var'],3)== np.round({"var": 0.20857275540714884}['var'],3)
+    assert np.round(transformer.left_tail_caps_['var'],3) == np.round({"var": -0.19661115230025186}['var'],3)
     # test transform output
     pd.testing.assert_frame_equal(X, df_transf)
-    assert X["var"].max() <= 0.20857275540714884
-    assert X["var"].min() >= -0.19661115230025186
-    assert df_normal_dist["var"].max() > 0.20857275540714884
-    assert df_normal_dist["var"].min() < -0.19661115230025186
+    assert np.round(X["var"].max(),3) <= np.round(0.20857275540714884,3)
+    assert np.round(X["var"].min(),3) >= np.round(-0.19661115230025186,3)
+    assert np.round(df_normal_dist["var"].max(),3) > np.round(0.20857275540714884,3)
+    assert np.round(df_normal_dist["var"].min(),3) < np.round(-0.19661115230025186,3)
 
 
 def test_iqr_capping_both_tails_with_fold_1(df_normal_dist):
@@ -71,14 +71,14 @@ def test_iqr_capping_both_tails_with_fold_1(df_normal_dist):
     )
 
     # test fit params
-    assert transformer.right_tail_caps_ == {"var": 0.21180113880445128}
-    assert transformer.left_tail_caps_ == {"var": -0.20247907173293223}
+    assert np.round(transformer.right_tail_caps_['var'],3) == np.round({"var": 0.21180113880445128}['var'],3)
+    assert np.round(transformer.left_tail_caps_['var'],3) == np.round({"var": -0.20247907173293223}['var'],3)
     # test transform output
     pd.testing.assert_frame_equal(X, df_transf)
-    assert X["var"].max() <= 0.21180113880445128
-    assert X["var"].min() >= -0.20247907173293223
-    assert df_normal_dist["var"].max() > 0.21180113880445128
-    assert df_normal_dist["var"].min() < -0.20247907173293223
+    assert np.round(X["var"].max(),3) <= np.round(0.21180113880445128,3)
+    assert np.round(X["var"].min(),3) >= np.round(-0.20247907173293223,3)
+    assert np.round(df_normal_dist["var"].max(),3) > np.round(0.21180113880445128,3)
+    assert np.round(df_normal_dist["var"].min(),3) < np.round(-0.20247907173293223,3)
 
 
 def test_iqr_capping_left_tail_with_fold_2(df_normal_dist):
@@ -94,11 +94,11 @@ def test_iqr_capping_left_tail_with_fold_2(df_normal_dist):
 
     # test fit params
     assert transformer.right_tail_caps_ == {}
-    assert transformer.left_tail_caps_ == {"var": -0.17486039103044}
+    assert np.round(transformer.left_tail_caps_['var'],3) == np.round({"var": -0.17486039103044}['var'],3)
     # test transform output
     pd.testing.assert_frame_equal(X, df_transf)
-    assert X["var"].min() >= -0.17486039103044
-    assert df_normal_dist["var"].min() < -0.17486039103044
+    assert np.round(X["var"].min(),3) >= np.round(-0.17486039103044,3)
+    assert np.round(df_normal_dist["var"].min(),3) < np.round(-0.17486039103044,3)
 
 
 def test_quantile_capping_both_tails_with_fold_10_percent(df_normal_dist):
@@ -116,14 +116,14 @@ def test_quantile_capping_both_tails_with_fold_10_percent(df_normal_dist):
     )
 
     # test fit params
-    assert transformer.right_tail_caps_ == {"var": 0.14712481122898166}
-    assert transformer.left_tail_caps_ == {"var": -0.12366227743232801}
+    assert np.round(transformer.right_tail_caps_['var'],3) == np.round({"var": 0.14712481122898166}['var'],3)
+    assert np.round(transformer.left_tail_caps_['var'],3) == np.round({"var": -0.12366227743232801}['var'],3)
     # test transform output
     pd.testing.assert_frame_equal(X, df_transf)
-    assert X["var"].max() <= 0.14712481122898166
-    assert X["var"].min() >= -0.12366227743232801
-    assert df_normal_dist["var"].max() > 0.14712481122898166
-    assert df_normal_dist["var"].min() < -0.12366227743232801
+    assert np.round(X["var"].max(),3) <= np.round(0.14712481122898166,3)
+    assert np.round(X["var"].min(),3) >= np.round(-0.12366227743232801,3)
+    assert np.round(df_normal_dist["var"].max(),3) > np.round(0.14712481122898166,3)
+    assert np.round(df_normal_dist["var"].min(),3) < np.round(-0.12366227743232801,3)
 
 
 def test_quantile_capping_both_tails_with_fold_15_percent(df_normal_dist):
@@ -138,12 +138,12 @@ def test_quantile_capping_both_tails_with_fold_15_percent(df_normal_dist):
     )
 
     # test fit params
-    assert transformer.right_tail_caps_ == {"var": 0.11823196128033647}
+    assert np.round(transformer.right_tail_caps_['var'],3) == np.round({"var": 0.11823196128033647}['var'],3)
     assert transformer.left_tail_caps_ == {}
     # test transform output
     pd.testing.assert_frame_equal(X, df_transf)
-    assert X["var"].max() <= 0.11823196128033647
-    assert df_normal_dist["var"].max() > 0.11823196128033647
+    assert np.round(X["var"].max(),3) <= np.round(0.11823196128033647,3)
+    assert np.round(df_normal_dist["var"].max(),3) > np.round(0.11823196128033647,3)
 
 
 def test_transformer_ignores_na_in_df(df_na):
@@ -179,8 +179,8 @@ def test_transformer_ignores_na_in_df(df_na):
     assert transformer.input_shape_ == (8, 6)
     # test transform output
     pd.testing.assert_frame_equal(X, df_transf)
-    assert X["Age"].max() <= 38.79255087111844
-    assert df_na["Age"].max() > 38.79255087111844
+    assert np.round(X["Age"].max(),3) <= np.round(38.79255087111844,3)
+    assert np.round(df_na["Age"].max(),3) > np.round(38.79255087111844,3)
 
 
 def test_error_if_capping_method_not_permitted():


### PR DESCRIPTION
I rounded numbers for test_winsorizer.py, for each one I use 3 decimals and I added for all comparisons. I use tox and pytest and passed successfully. If you think that is ok, I can apply the same rule to the rest of the test files.