### PR TITLE
#233 MathematicalCombination to take in null values

### DIFF
--- a/feature_engine/creation/mathematical_combination.py
+++ b/feature_engine/creation/mathematical_combination.py
@@ -86,7 +86,7 @@ class MathematicalCombination(BaseEstimator, TransformerMixin):
         If `new_variable_names = None`, the transformer will assign an arbitrary name
         to the newly created features starting by the name of the mathematical
         operation, followed by the variables combined separated by -.
-        
+
     missing_values : string, default='raise'
         Indicates if missing values should be ignored or raised. If
         `missing_values='raise'` the transformer will return an error if the

--- a/feature_engine/creation/mathematical_combination.py
+++ b/feature_engine/creation/mathematical_combination.py
@@ -208,8 +208,7 @@ class MathematicalCombination(BaseEstimator, TransformerMixin):
            - If the input is not a Pandas DataFrame
            - If any user provided variables in variables_to_combine are not numerical
         ValueError
-           If the variable(s) contain null values when the parameter
-           skipna is set to True
+           If the variable(s) contain null values when skipna is set to True
 
         Returns
         -------
@@ -270,8 +269,7 @@ class MathematicalCombination(BaseEstimator, TransformerMixin):
         TypeError
            If the input is not a Pandas DataFrame
         ValueError
-           - If the variable(s) contain null values when the parameter
-            skipna is set to True
+           - If the variable(s) contain null values when skipna is set to True
            - If the dataframe is not of the same size as that used in fit()
 
         Returns

--- a/feature_engine/creation/mathematical_combination.py
+++ b/feature_engine/creation/mathematical_combination.py
@@ -90,7 +90,8 @@ class MathematicalCombination(BaseEstimator, TransformerMixin):
     missing_values : string, default='raise'
         Indicates if missing values should be ignored or raised. If
         `missing_values='raise'` the transformer will return an error if the
-        training or the datasets to transform contain missing values.
+        the datasets to fit or transform contain missing values. If the value 
+        is set to 'ignore', operations will be carried out.
 
     Attributes
     ----------
@@ -213,7 +214,7 @@ class MathematicalCombination(BaseEstimator, TransformerMixin):
            - If the input is not a Pandas DataFrame
            - If any user provided variables in variables_to_combine are not numerical
         ValueError
-           If the variable(s) contain null values when skipna is set to True
+           If the variable(s) contain null values when missing_values = raise
 
         Returns
         -------

--- a/feature_engine/creation/mathematical_combination.py
+++ b/feature_engine/creation/mathematical_combination.py
@@ -181,7 +181,8 @@ class MathematicalCombination(BaseEstimator, TransformerMixin):
         self.new_variables_names = new_variables_names
         self.math_operations = math_operations
 
-    def fit(self, X: pd.DataFrame, y: Optional[pd.Series] = None):
+    def fit(self, X: pd.DataFrame, y: Optional[pd.Series] = None,
+            skipna: Optional[bool] = True):
         """
         This transformer does not learn parameters.
 
@@ -197,13 +198,18 @@ class MathematicalCombination(BaseEstimator, TransformerMixin):
         y : pandas Series, or np.array. Defaults to None.
             It is not needed in this transformer. You can pass y or None.
 
+        skipna: bool. Defaults to True.
+            Whether to raise Value error if variables contain null values.
+
+
         Raises
         ------
         TypeError
            - If the input is not a Pandas DataFrame
            - If any user provided variables in variables_to_combine are not numerical
         ValueError
-           If the variable(s) contain null values
+           If the variable(s) contain null values when the parameter
+           skipna is set to True
 
         Returns
         -------
@@ -219,7 +225,8 @@ class MathematicalCombination(BaseEstimator, TransformerMixin):
         )
 
         # check if dataset contains na
-        _check_contains_na(X, self.variables_to_combine)
+        if not skipna:
+            _check_contains_na(X, self.variables_to_combine)
 
         if self.math_operations is None:
             self.math_operations_ = ["sum", "prod", "mean", "std", "max", "min"]
@@ -246,7 +253,7 @@ class MathematicalCombination(BaseEstimator, TransformerMixin):
 
         return self
 
-    def transform(self, X: pd.DataFrame) -> pd.DataFrame:
+    def transform(self, X: pd.DataFrame, skipna: Optional[bool] = True) -> pd.DataFrame:
         """
         Combine the variables with the mathematical operations.
 
@@ -255,12 +262,16 @@ class MathematicalCombination(BaseEstimator, TransformerMixin):
         X : pandas dataframe of shape = [n_samples, n_features]
             The data to transform.
 
+        skipna: bool. Defaults to True.
+            Whether to raise Value error if the variables contains null values.
+
         Raises
         ------
         TypeError
            If the input is not a Pandas DataFrame
         ValueError
-           - If the variable(s) contain null values
+           - If the variable(s) contain null values when the parameter
+            skipna is set to True
            - If the dataframe is not of the same size as that used in fit()
 
         Returns
@@ -276,7 +287,8 @@ class MathematicalCombination(BaseEstimator, TransformerMixin):
         X = _is_dataframe(X)
 
         # check if dataset contains na
-        _check_contains_na(X, self.variables_to_combine)
+        if not skipna:
+            _check_contains_na(X, self.variables_to_combine)
 
         # Check if input data contains same number of columns as dataframe used to fit.
         _check_input_matches_training_df(X, self.input_shape_[1])

--- a/tests/test_creation/test_mathematical_combination.py
+++ b/tests/test_creation/test_mathematical_combination.py
@@ -273,18 +273,18 @@ def test_variable_names_when_df_cols_are_integers(df_numeric_columns):
     pd.testing.assert_frame_equal(X, ref)
 
 
-def test_error_when_null_values_in_variable():
-    with pytest.raises(ValueError):
+    def test_error_when_null_values_in_variable():
+        with pytest.raises(ValueError):
 
-        math_combinator_mean = MathematicalCombination(
-            variables_to_combine=['fixed acidity', 'volatile acidity'],
-            math_operations=['mean'],
-            new_variables_names=['avg_acidity']
-        )
+            math_combinator_mean = MathematicalCombination(
+                variables_to_combine=['fixed acidity', 'volatile acidity'],
+                math_operations=['mean'],
+                new_variables_names=['avg_acidity']
+            )
 
-        ref = pd.DataFrame.from_dict({
-            "fixed acidity": None,
-            "volatile acidity": 0.7
-        })
-        math_combinator_mean.fit(ref)
-        math_combinator_mean.transform(ref)
+            ref = pd.DataFrame.from_dict({
+                "fixed acidity": None,
+                "volatile acidity": 0.7
+            })
+            math_combinator_mean.fit(ref)
+            math_combinator_mean.transform(ref)

--- a/tests/test_creation/test_mathematical_combination.py
+++ b/tests/test_creation/test_mathematical_combination.py
@@ -271,3 +271,20 @@ def test_variable_names_when_df_cols_are_integers(df_numeric_columns):
     }
     # transform params
     pd.testing.assert_frame_equal(X, ref)
+
+
+def test_error_when_null_values_in_variable():
+    with pytest.raises(ValueError):
+
+        math_combinator_mean = MathematicalCombination(
+            variables_to_combine=['fixed acidity', 'volatile acidity'],
+            math_operations=['mean'],
+            new_variables_names=['avg_acidity']
+        )
+
+        ref = pd.DataFrame.from_dict({
+            "fixed acidity": None,
+            "volatile acidity": 0.7
+        })
+        math_combinator_mean.fit(ref)
+        math_combinator_mean.transform(ref)

--- a/tests/test_creation/test_mathematical_combination.py
+++ b/tests/test_creation/test_mathematical_combination.py
@@ -272,7 +272,6 @@ def test_variable_names_when_df_cols_are_integers(df_numeric_columns):
     # transform params
     pd.testing.assert_frame_equal(X, ref)
 
-
     def test_error_when_null_values_in_variable():
         with pytest.raises(ValueError):
 

--- a/tests/test_creation/test_mathematical_combination.py
+++ b/tests/test_creation/test_mathematical_combination.py
@@ -272,18 +272,36 @@ def test_variable_names_when_df_cols_are_integers(df_numeric_columns):
     # transform params
     pd.testing.assert_frame_equal(X, ref)
 
-    def test_error_when_null_values_in_variable():
-        with pytest.raises(ValueError):
 
-            math_combinator_mean = MathematicalCombination(
-                variables_to_combine=['fixed acidity', 'volatile acidity'],
-                math_operations=['mean'],
-                new_variables_names=['avg_acidity']
-            )
+def test_error_when_null_values_in_variable():
+    with pytest.raises(ValueError):
 
-            ref = pd.DataFrame.from_dict({
-                "fixed acidity": None,
-                "volatile acidity": 0.7
-            })
-            math_combinator_mean.fit(ref)
-            math_combinator_mean.transform(ref)
+        math_combinator_mean = MathematicalCombination(
+            variables_to_combine=['fixed acidity', 'volatile acidity'],
+            math_operations=['mean'],
+            new_variables_names=['avg_acidity']
+        )
+
+        ref = pd.DataFrame.from_dict({
+            "fixed acidity": None,
+            "volatile acidity": 0.7
+        })
+        math_combinator_mean.fit(ref)
+        math_combinator_mean.transform(ref)
+
+
+def test_no_error_when_null_values_in_variable():
+
+    math_combinator_mean = MathematicalCombination(
+        variables_to_combine=['fixed acidity', 'volatile acidity'],
+        math_operations=['mean'],
+        new_variables_names=['avg_acidity'],
+        missing_values="ignore"
+    )
+
+    ref = pd.DataFrame.from_dict({
+        "fixed acidity": None,
+        "volatile acidity": 0.7
+    })
+    math_combinator_mean.fit(ref)
+    math_combinator_mean.transform(ref)


### PR DESCRIPTION
Optional parameter _**[skipna: Optional[bool] = True]**_ introduced to allow users the ability to provide variables containing nulls. If _skipna_ is set to True, the following must be taken into account:

1. It won't raise a value error.
2. Pandas will try to perform operations according to its internal logic. No extra null handling logic has been implemented. Results might be numbers or NaN. Ex: Sum(1,NaN) = 1 while Std(1, NaN) = NaN

