### PR TITLE
Check one hot encoder for variables with 2 categories. #191

### DIFF
--- a/feature_engine/encoding/one_hot.py
+++ b/feature_engine/encoding/one_hot.py
@@ -112,10 +112,10 @@ class OneHotEncoder(BaseCategoricalTransformer):
     """
 
     def __init__(
-        self,
-        top_categories: Optional[int] = None,
-        variables: Union[None, int, str, List[Union[str, int]]] = None,
-        drop_last: bool = False,
+            self,
+            top_categories: Optional[int] = None,
+            variables: Union[None, int, str, List[Union[str, int]]] = None,
+            drop_last: bool = False,
     ) -> None:
 
         if top_categories and not isinstance(top_categories, int):
@@ -176,10 +176,10 @@ class OneHotEncoder(BaseCategoricalTransformer):
                     self.encoder_dict_[var] = [
                         x
                         for x in X[var]
-                        .value_counts()
-                        .sort_values(ascending=False)
-                        .head(self.top_categories)
-                        .index
+                            .value_counts()
+                            .sort_values(ascending=False)
+                            .head(self.top_categories)
+                            .index
                     ]
                 elif len(X[var].unique()) == 2:
                     self.encoder_dict_[var] = [

--- a/feature_engine/encoding/one_hot.py
+++ b/feature_engine/encoding/one_hot.py
@@ -169,17 +169,27 @@ class OneHotEncoder(BaseCategoricalTransformer):
                     category_ls = [x for x in X[var].unique()]
                     self.encoder_dict_[var] = category_ls[:-1]
                 else:
-                    self.encoder_dict_[var] = X[var].unique()
+                    self.encoder_dict_[var] = X[var].unique() if len(X[var].unique()) > 2 else X[var].unique()[0]
 
             else:
-                self.encoder_dict_[var] = [
-                    x
-                    for x in X[var]
-                    .value_counts()
-                    .sort_values(ascending=False)
-                    .head(self.top_categories)
-                    .index
-                ]
+                if self.top_categories > 2:
+                    self.encoder_dict_[var] = [
+                        x
+                        for x in X[var]
+                        .value_counts()
+                        .sort_values(ascending=False)
+                        .head(self.top_categories)
+                        .index
+                    ]
+                else:
+                    self.encoder_dict_[var] = [
+                        x
+                        for x in X[var]
+                            .value_counts()
+                            .sort_values(ascending=False)
+                            .head(1)
+                            .index
+                    ]
 
         self._check_encoding_dictionary()
 

--- a/feature_engine/encoding/one_hot.py
+++ b/feature_engine/encoding/one_hot.py
@@ -169,27 +169,27 @@ class OneHotEncoder(BaseCategoricalTransformer):
                     category_ls = [x for x in X[var].unique()]
                     self.encoder_dict_[var] = category_ls[:-1]
                 else:
-                    self.encoder_dict_[var] = X[var].unique() if len(X[var].unique()) > 2 else X[var].unique()[0]
+                    self.encoder_dict_[var] = X[var].unique() \
+                        if len(X[var].unique()) > 2 \
+                        else X[var].unique()[0]
 
             else:
                 if self.top_categories >= 2 and len(X[var].unique()) > 2:
-                    self.encoder_dict_[var] = [
-                        x
-                        for x in X[var]
-                            .value_counts()
-                            .sort_values(ascending=False)
-                            .head(self.top_categories)
-                            .index
-                    ]
+                    self.encoder_dict_[var] = [x
+                                               for x in X[var]
+                                               .value_counts()
+                                               .sort_values(ascending=False)
+                                               .head(self.top_categories)
+                                               .index
+                                               ]
                 elif len(X[var].unique()) == 2:
-                    self.encoder_dict_[var] = [
-                        x
-                        for x in X[var]
-                            .value_counts()
-                            .sort_values(ascending=False)
-                            .head(1)
-                            .index
-                    ]
+                    self.encoder_dict_[var] = [x
+                                               for x in X[var]
+                                               .value_counts()
+                                               .sort_values(ascending=False)
+                                               .head(1)
+                                               .index
+                                               ]
         self._check_encoding_dictionary()
 
         self.input_shape_ = X.shape

--- a/feature_engine/encoding/one_hot.py
+++ b/feature_engine/encoding/one_hot.py
@@ -172,7 +172,7 @@ class OneHotEncoder(BaseCategoricalTransformer):
                     self.encoder_dict_[var] = X[var].unique() if len(X[var].unique()) > 2 else X[var].unique()[0]
 
             else:
-                if self.top_categories > 2:
+                if self.top_categories >= 2 and len(X[var].unique()) > 2:
                     self.encoder_dict_[var] = [
                         x
                         for x in X[var]
@@ -181,7 +181,7 @@ class OneHotEncoder(BaseCategoricalTransformer):
                         .head(self.top_categories)
                         .index
                     ]
-                else:
+                elif len(X[var].unique()) == 2:
                     self.encoder_dict_[var] = [
                         x
                         for x in X[var]
@@ -190,7 +190,6 @@ class OneHotEncoder(BaseCategoricalTransformer):
                             .head(1)
                             .index
                     ]
-
         self._check_encoding_dictionary()
 
         self.input_shape_ = X.shape

--- a/feature_engine/encoding/one_hot.py
+++ b/feature_engine/encoding/one_hot.py
@@ -176,21 +176,20 @@ class OneHotEncoder(BaseCategoricalTransformer):
                         if X[var].nunique() > 2 \
                         else X[var].unique()[0]
 
-            else:  # If top categories are selected
+            else:  # If B) top categories are selected
                 if ((X[var].nunique() > 2) and
-                        # The variable is non-binary
+                        # 1) The variable is non-binary
                         (self.top_categories >= 2) and
-                        # The user selects more than two categories
+                        # 2) The user selects more than two categories
                         (X[var].nunique()) != self.top_categories):
-                    # The top categories = number of categories
-
+                    # 3) The top categories = number of categories
+                    # Then) Select as many dummy variables as number of categories
                     self.encoder_dict_[var] = [x for x in X[var]
                                                .value_counts()
                                                .sort_values(ascending=False)
                                                .head(self.top_categories)
                                                .index
-                                               ] # Select as many dummy variables as number of categories
-                                                 #
+                                               ]
                 elif ((X[var].nunique() <= 2) or
                       # When the variable is binary
                       (X[var].nunique() == self.top_categories)):

--- a/feature_engine/encoding/one_hot.py
+++ b/feature_engine/encoding/one_hot.py
@@ -112,10 +112,10 @@ class OneHotEncoder(BaseCategoricalTransformer):
     """
 
     def __init__(
-            self,
-            top_categories: Optional[int] = None,
-            variables: Union[None, int, str, List[Union[str, int]]] = None,
-            drop_last: bool = False,
+        self,
+        top_categories: Optional[int] = None,
+        variables: Union[None, int, str, List[Union[str, int]]] = None,
+        drop_last: bool = False,
     ) -> None:
 
         if top_categories and not isinstance(top_categories, int):

--- a/feature_engine/encoding/one_hot.py
+++ b/feature_engine/encoding/one_hot.py
@@ -164,7 +164,7 @@ class OneHotEncoder(BaseCategoricalTransformer):
         self.encoder_dict_ = {}
 
         for var in self.variables:
-            if not self.top_categories:  # If top categories are not selected
+            if not self.top_categories:  # A) If top categories are not selected
                 if self.drop_last:  # When drop last is True,
                     # it automatically drops second category in binary variable
                     category_ls = [x for x in X[var].unique()]
@@ -182,7 +182,7 @@ class OneHotEncoder(BaseCategoricalTransformer):
                         (self.top_categories >= 2) and
                         # 2) The user selects more than two categories
                         (X[var].nunique()) != self.top_categories):
-                    # 3) The top categories = number of categories
+                    # 3) The top categories != number of categories
                     # Then) Select as many dummy variables as number of categories
                     self.encoder_dict_[var] = [x for x in X[var]
                                                .value_counts()
@@ -199,6 +199,7 @@ class OneHotEncoder(BaseCategoricalTransformer):
                                                .sort_values(ascending=False)
                                                .index
                                                ][:-1]
+
         self._check_encoding_dictionary()
 
         self.input_shape_ = X.shape

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -133,6 +133,7 @@ def df_enc_big():
 
     return df
 
+
 @pytest.fixture(scope="module")
 def df_enc_small():
     df = {

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -133,6 +133,24 @@ def df_enc_big():
 
     return df
 
+@pytest.fixture(scope="module")
+def df_enc_small():
+    df = {
+        "var_A": ["A"] * 6
+        + ["B"] * 4,
+        "var_B": ["A"] * 6
+        + ["C"] * 3
+        + ["G"] * 1,
+        "var_C": ["A"] * 4
+        + ["B"] * 1
+        + ["C"] * 1
+        + ["D"] * 1
+        + ["F"] * 2
+        + ["G"] * 1,
+    }
+    df = pd.DataFrame(df)
+    return df
+
 
 @pytest.fixture(scope="module")
 def df_enc_big_na():

--- a/tests/test_encoding/test_onehot_encoder.py
+++ b/tests/test_encoding/test_onehot_encoder.py
@@ -134,3 +134,41 @@ def test_transform_raises_error_if_df_contains_na(df_enc_big, df_enc_big_na):
         encoder = OneHotEncoder()
         encoder.fit(df_enc_big)
         encoder.transform(df_enc_big_na)
+
+
+def test_one_dummy_variable_for_two_categories(df_enc_small):
+    # test case 6: encode only the most popular categories
+    encoder = OneHotEncoder(top_categories=None, variables=None, drop_last=False)
+    X = encoder.fit_transform(df_enc_small)
+    # test fit attr
+    transf = {
+        "var_A_A": 6,
+        "var_B_A":6,
+        "var_B_C": 3,
+        "var_B_G": 1
+            }
+
+    assert encoder.input_shape_ == (10, 3)
+    # test transform output
+    for col in transf.keys():
+        assert X[col].sum() == transf[col]
+
+    encoder_top_cat = OneHotEncoder(top_categories=2, variables=None, drop_last=False)
+    X_top_cat = encoder_top_cat.fit_transform(df_enc_small)
+    # test fit attr
+    transf = {
+        "var_A_A": 6,
+        "var_B_A": 6,
+        "var_B_C": 3,
+        "var_C_A": 4,
+        "var_C_F": 2
+    }
+
+    assert encoder_top_cat.input_shape_ == (10, 3)
+    # test transform output
+    for col in transf.keys():
+        assert X_top_cat[col].sum() == transf[col]
+    assert "var_B_G" not in X_top_cat.columns
+    assert "var_C_C" not in X_top_cat.columns
+    assert "var_C_D" not in X_top_cat.columns
+    assert "var_C_E" not in X_top_cat.columns

--- a/tests/test_encoding/test_onehot_encoder.py
+++ b/tests/test_encoding/test_onehot_encoder.py
@@ -143,10 +143,10 @@ def test_one_dummy_variable_for_two_categories(df_enc_small):
     # test fit attr
     transf = {
         "var_A_A": 6,
-        "var_B_A":6,
+        "var_B_A": 6,
         "var_B_C": 3,
         "var_B_G": 1
-            }
+    }
 
     assert encoder.input_shape_ == (10, 3)
     # test transform output


### PR DESCRIPTION
#191 Fixed the bug that creates two dummy variables when there are two categories. Added test case and a new test dataframe