### PR TITLE
modify np.float to float

### DIFF
--- a/feature_engine/encoding/count_frequency.py
+++ b/feature_engine/encoding/count_frequency.py
@@ -119,7 +119,7 @@ class CountFrequencyEncoder(BaseCategoricalTransformer):
                 self.encoder_dict_[var] = X[var].value_counts().to_dict()
 
             elif self.encoding_method == "frequency":
-                n_obs = np.float(len(X))
+                n_obs = float(len(X))
                 self.encoder_dict_[var] = (X[var].value_counts() / n_obs).to_dict()
 
         self._check_encoding_dictionary()

--- a/feature_engine/encoding/count_frequency.py
+++ b/feature_engine/encoding/count_frequency.py
@@ -4,7 +4,6 @@
 from typing import Optional, List, Union
 
 import pandas as pd
-import numpy as np
 
 from feature_engine.variable_manipulation import _check_input_parameter_variables
 from feature_engine.encoding.base_encoder import BaseCategoricalTransformer

--- a/feature_engine/encoding/rare_label.py
+++ b/feature_engine/encoding/rare_label.py
@@ -141,7 +141,7 @@ class RareLabelEncoder(BaseCategoricalTransformer):
 
                 # if the variable has more than the indicated number of categories
                 # the encoder will learn the most frequent categories
-                t = pd.Series(X[var].value_counts() / np.float(len(X)))
+                t = pd.Series(X[var].value_counts() / float(len(X)))
 
                 # non-rare labels:
                 freq_idx = t[t >= self.tol].index

--- a/feature_engine/selection/drop_constant_features.py
+++ b/feature_engine/selection/drop_constant_features.py
@@ -1,6 +1,5 @@
 from typing import List, Union
 
-import numpy as np
 import pandas as pd
 
 from feature_engine.dataframe_checks import (

--- a/feature_engine/selection/drop_constant_features.py
+++ b/feature_engine/selection/drop_constant_features.py
@@ -129,7 +129,7 @@ class DropConstantFeatures(BaseSelector):
             for feature in self.variables:
                 # find most frequent value / category in the variable
                 predominant = (
-                    (X[feature].value_counts() / np.float(len(X)))
+                    (X[feature].value_counts() / float(len(X)))
                     .sort_values(ascending=False)
                     .values[0]
                 )


### PR DESCRIPTION
### Description

This is a simple PR to change the use of numpy aliases for builtins like `float`.

It eliminates deprecation warnings for numpy >= 1.20, e.g.
```
***/feature_engine/encoding/count_frequency.py:122: DeprecationWarning: `np.float` is a deprecated alias for the builtin `float`. To silence this warning, use `float` by itself. Doing this will not modify any behavior and is safe. If you specifically wanted the numpy scalar type, use `np.float64` here.
  Deprecated in NumPy 1.20; for more details and guidance: https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations
    n_obs = np.float(len(X))
```

See numpy 1.20 release notes on deprecations

https://numpy.org/doc/stable/release/1.20.0-notes.html