### PR TITLE
support for pd.CategoricalDtype to determine categorical features in dataframe

### DIFF
--- a/feature_engine/variable_manipulation.py
+++ b/feature_engine/variable_manipulation.py
@@ -110,7 +110,7 @@ def _find_or_check_categorical_variables(
         variables = [variables]
 
     elif not variables:
-        variables = list(X.select_dtypes(include="O").columns)
+        variables = list(X.select_dtypes(include=["O", "category"]).columns)
         if len(variables) == 0:
             raise ValueError(
                 "No categorical variables in this dataframe. Please check variable "
@@ -118,9 +118,9 @@ def _find_or_check_categorical_variables(
             )
 
     else:
-        if any(X[variables].select_dtypes(exclude="O").columns):
+        if any(X[variables].select_dtypes(exclude=["O", "category"]).columns):
             raise TypeError(
-                "Some of the variables are not categorical. Please cast them as object "
+                "Some of the variables are not categorical. Please cast them as object or category "
                 "before calling this transformer"
             )
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,6 +14,7 @@ def df_vartypes():
     }
 
     df = pd.DataFrame(data)
+    df['City'] = df['City'].astype("category")
 
     return df
 
@@ -28,8 +29,9 @@ def df_numeric_columns():
         4: pd.date_range("2020-02-24", periods=4, freq="T"),
     }
 
+    cat_type = pd.CategoricalDtype(["London", "Manchester", "Liverpool", "Bristol"], ordered=False)
     df = pd.DataFrame(data)
-
+    df.loc[:, 1] = df.loc[:, 1].astype(cat_type)
     return df
 
 

--- a/tests/test_creation/test_combine_with_reference_feature.py
+++ b/tests/test_creation/test_combine_with_reference_feature.py
@@ -113,7 +113,7 @@ def test_all_binary_operation(df_vartypes):
             "Age_mul_Marks": [18.0, 16.8, 13.299999999999999, 10.799999999999999],
         }
     )
-
+    ref['City'] = ref['City'].astype("category")
     # init params
     assert transformer.variables_to_combine == ["Age"]
     assert transformer.reference_variables == ["Marks"]
@@ -146,7 +146,7 @@ def test_operations_with_multiple_variables(df_vartypes):
             "Marks_sub_Marks": [0.0, 0.0, 0.0, 0.0],
         }
     )
-
+    ref['City'] = ref['City'].astype("category")
     # init params
     assert transformer.variables_to_combine == ["Age", "Marks"]
     assert transformer.reference_variables == ["Age", "Marks"]
@@ -181,7 +181,7 @@ def test_user_enters_output_variable_names(df_vartypes):
             "GranAmigo": [0.0, 0.0, 0.0, 0.0],
         }
     )
-
+    ref['City'] = ref['City'].astype("category")
     # init params
     assert transformer.variables_to_combine == ["Age", "Marks"]
     assert transformer.reference_variables == ["Age", "Marks"]

--- a/tests/test_creation/test_mathematical_combination.py
+++ b/tests/test_creation/test_mathematical_combination.py
@@ -100,7 +100,7 @@ def test_default_parameters(df_vartypes):
             "min(Age-Marks)": [0.9, 0.8, 0.7, 0.6],
         }
     )
-
+    ref['City'] = ref['City'].astype("category")
     # init params
     assert transformer.variables_to_combine == ["Age", "Marks"]
     assert transformer.math_operations is None
@@ -151,7 +151,7 @@ def test_user_enters_two_operations(df_vartypes):
             "mean(Age-Marks)": [10.45, 10.9, 9.85, 9.3],
         }
     )
-
+    ref['City'] = ref['City'].astype("category")
     # init params
     assert transformer.variables_to_combine == ["Age", "Marks"]
     assert transformer.math_operations == ["sum", "mean"]
@@ -186,7 +186,7 @@ def test_user_enters_output_variable_names(df_vartypes):
             "mean_of_two_vars": [10.45, 10.9, 9.85, 9.3],
         }
     )
-
+    ref['City'] = ref['City'].astype("category")
     # init params
     assert transformer.variables_to_combine == ["Age", "Marks"]
     assert transformer.math_operations == ["sum", "mean"]
@@ -219,7 +219,7 @@ def test_one_mathematical_operation(df_vartypes):
             "sum(Age-Marks)": [20.9, 21.8, 19.7, 18.6],
         }
     )
-
+    ref['City'] = ref['City'].astype("category")
     # init params
     assert transformer.variables_to_combine == ["Age", "Marks"]
     assert transformer.math_operations == ["sum"]
@@ -255,6 +255,8 @@ def test_variable_names_when_df_cols_are_integers(df_numeric_columns):
             "min(2-3)": [0.9, 0.8, 0.7, 0.6],
         }
     )
+    cat_type = pd.CategoricalDtype(["London", "Manchester", "Liverpool", "Bristol"], ordered=False)
+    ref.loc[:, 1] = ref.loc[:, 1].astype(cat_type)
 
     # init params
     assert transformer.variables_to_combine == [2, 3]
@@ -322,5 +324,6 @@ def test_no_error_when_null_values_in_variable(df_vartypes):
             "mean(Age-Marks)": [10.45, 0.8, 9.85, 9.3],
         }
     )
+    ref['City'] = ref['City'].astype("category")
     # transform params
     pd.testing.assert_frame_equal(X, ref)

--- a/tests/test_wrappers/test_sklearn_wrapper.py
+++ b/tests/test_wrappers/test_sklearn_wrapper.py
@@ -207,7 +207,7 @@ def test_sklearn_ohe_object_many_features(df_vartypes):
             "City_Manchester": [0, 1, 0, 0],
         }
     )
-
+    ref['City'] = ref['City'].astype("category")
     transformed_df = transformer.fit_transform(df_vartypes[variables_to_encode])
 
     # init params
@@ -280,7 +280,7 @@ def test_sklearn_ohe_all_features(df_vartypes):
             "dob_2020-02-24T00:03:00.000000000": [0, 0, 0, 1],
         }
     )
-
+    ref['City'] = ref['City'].astype("category")
     transformed_df = transformer.fit_transform(df_vartypes)
 
     # init params


### PR DESCRIPTION
This PR contains changes for support of pd.CategoricalDtype to determine categorical features in dataframe along with dtype="object".